### PR TITLE
Option to disable the cavenium based tools

### DIFF
--- a/assets/caveworld/lang/en_US.lang
+++ b/assets/caveworld/lang/en_US.lang
@@ -70,6 +70,8 @@ caveworld.config.general.miningPoints=Mining Points
 caveworld.config.general.miningPoints.tooltip=Specify the mining points.
 caveworld.config.general.miningPointValidItems=Mining Point Valid Items
 caveworld.config.general.miningPointValidItems.tooltip=Specify the valid items that can getting mining point.
+caveworld.config.general.disableMiningTools=Disable Mining Tools 
+caveworld.config.general.disableMiningTools.tooltip=Disable cavenium based mining tools if you run into issues with the amount of NBT data they store.
 caveworld.config.general.randomiteDrops=Randomite Drops
 caveworld.config.general.randomiteDrops.tooltip=Specify the drop items for Randomite Ore. It can specify up to 500 items.
 caveworld.config.general.randomitePotions=Randomite Potions
@@ -270,6 +272,8 @@ caveworld.bowmode.normal=NORMAL
 caveworld.bowmode.rapid=RAPID
 caveworld.bowmode.snipe=SNIPE
 caveworld.bowmode.torch=TORCH
+
+caveworld.disabled=DISABLED
 
 tile.portalCaveworld.name=Caveworld Portal Block
 tile.rope.name=Rope

--- a/caveworld/core/Caveworld.java
+++ b/caveworld/core/Caveworld.java
@@ -221,111 +221,93 @@ public class Caveworld
 	{
 		SubItemHelper.cacheSubBlocks(event.getSide());
 		SubItemHelper.cacheSubItems(event.getSide());
+		
+		if (!Config.disableMiningTools) {
 
-		for (Item item : GameData.getItemRegistry().typeSafeIterable())
-		{
-			CaveUtils.isItemPickaxe(item);
-			CaveUtils.isItemAxe(item);
-			CaveUtils.isItemShovel(item);
-			CaveUtils.isItemHoe(item);
-		}
+			for (Item item : GameData.getItemRegistry().typeSafeIterable()) {
+				CaveUtils.isItemPickaxe(item);
+				CaveUtils.isItemAxe(item);
+				CaveUtils.isItemShovel(item);
+				CaveUtils.isItemHoe(item);
+			}
 
-		for (Block block : GameData.getBlockRegistry().typeSafeIterable())
-		{
-			try
-			{
-				List<ItemStack> list = SubItemHelper.getSubBlocks(block);
+			for (Block block : GameData.getBlockRegistry().typeSafeIterable()) {
+				try {
+					List<ItemStack> list = SubItemHelper.getSubBlocks(block);
 
-				if (list.isEmpty())
-				{
-					if (Strings.nullToEmpty(block.getHarvestTool(0)).equalsIgnoreCase("pickaxe") || CaveItems.mining_pickaxe.func_150897_b(block) ||
-						block instanceof BlockOre || block instanceof BlockRedstoneOre || block instanceof BlockGlowstone)
-					{
-						ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 0));
+					if (list.isEmpty()) {
+						if (Strings.nullToEmpty(block.getHarvestTool(0)).equalsIgnoreCase("pickaxe") || CaveItems.mining_pickaxe.func_150897_b(block) ||
+								block instanceof BlockOre || block instanceof BlockRedstoneOre || block instanceof BlockGlowstone) {
+							ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 0));
 
-						if (block instanceof BlockRotatedPillar)
-						{
-							ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 4));
-							ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 8));
-						}
-					}
-
-					if (CaveUtils.isWood(block, 0))
-					{
-						ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 0));
-
-						if (block instanceof BlockRotatedPillar)
-						{
-							ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 4));
-							ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 8));
-						}
-					}
-
-					if (Strings.nullToEmpty(block.getHarvestTool(0)).equalsIgnoreCase("shovel") || CaveItems.digging_shovel.func_150897_b(block) ||
-						block.getMaterial() == Material.ground || block.getMaterial() == Material.grass || block.getMaterial() == Material.sand || block.getMaterial() == Material.snow || block.getMaterial() == Material.craftedSnow)
-					{
-						ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(block, 0));
-
-						if (block instanceof BlockRotatedPillar)
-						{
-							ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(block, 4));
-							ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(block, 8));
-						}
-					}
-				}
-				else for (ItemStack itemstack : list)
-				{
-					if (itemstack != null && itemstack.getItem() != null)
-					{
-						Block sub = Block.getBlockFromItem(itemstack.getItem());
-
-						if (sub == Blocks.air)
-						{
-							continue;
-						}
-
-						int meta = itemstack.getItemDamage();
-
-						if (Strings.nullToEmpty(sub.getHarvestTool(meta)).equalsIgnoreCase("pickaxe") ||
-							CaveItems.mining_pickaxe.func_150897_b(sub) || sub instanceof BlockOre || sub instanceof BlockRedstoneOre || block instanceof BlockGlowstone)
-						{
-							ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta));
-
-							if (sub instanceof BlockRotatedPillar)
-							{
-								ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 4));
-								ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 8));
+							if (block instanceof BlockRotatedPillar) {
+								ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 4));
+								ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 8));
 							}
 						}
 
-						if (CaveUtils.isWood(sub, meta))
-						{
-							ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta));
+						if (CaveUtils.isWood(block, 0)) {
+							ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 0));
 
-							if (sub instanceof BlockRotatedPillar)
-							{
-								ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 4));
-								ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 8));
+							if (block instanceof BlockRotatedPillar) {
+								ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 4));
+								ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(block, 8));
 							}
 						}
 
-						if (Strings.nullToEmpty(sub.getHarvestTool(meta)).equalsIgnoreCase("shovel") || CaveItems.digging_shovel.func_150897_b(sub) ||
-							sub.getMaterial() == Material.ground || sub.getMaterial() == Material.grass || sub.getMaterial() == Material.sand || sub.getMaterial() == Material.snow || sub.getMaterial() == Material.craftedSnow)
-						{
-							ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta));
+						if (Strings.nullToEmpty(block.getHarvestTool(0)).equalsIgnoreCase("shovel") || CaveItems.digging_shovel.func_150897_b(block) ||
+								block.getMaterial() == Material.ground || block.getMaterial() == Material.grass || block.getMaterial() == Material.sand || block.getMaterial() == Material.snow || block.getMaterial() == Material.craftedSnow) {
+							ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(block, 0));
 
-							if (sub instanceof BlockRotatedPillar)
-							{
-								ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 4));
-								ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 8));
+							if (block instanceof BlockRotatedPillar) {
+								ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(block, 4));
+								ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(block, 8));
+							}
+						}
+					} else for (ItemStack itemstack : list) {
+						if (itemstack != null && itemstack.getItem() != null) {
+							Block sub = Block.getBlockFromItem(itemstack.getItem());
+
+							if (sub == Blocks.air) {
+								continue;
+							}
+
+							int meta = itemstack.getItemDamage();
+
+							if (Strings.nullToEmpty(sub.getHarvestTool(meta)).equalsIgnoreCase("pickaxe") ||
+									CaveItems.mining_pickaxe.func_150897_b(sub) || sub instanceof BlockOre || sub instanceof BlockRedstoneOre || block instanceof BlockGlowstone) {
+								ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta));
+
+								if (sub instanceof BlockRotatedPillar) {
+									ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 4));
+									ItemMiningPickaxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 8));
+								}
+							}
+
+							if (CaveUtils.isWood(sub, meta)) {
+								ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta));
+
+								if (sub instanceof BlockRotatedPillar) {
+									ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 4));
+									ItemLumberingAxe.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 8));
+								}
+							}
+
+							if (Strings.nullToEmpty(sub.getHarvestTool(meta)).equalsIgnoreCase("shovel") || CaveItems.digging_shovel.func_150897_b(sub) ||
+									sub.getMaterial() == Material.ground || sub.getMaterial() == Material.grass || sub.getMaterial() == Material.sand || sub.getMaterial() == Material.snow || sub.getMaterial() == Material.craftedSnow) {
+								ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta));
+
+								if (sub instanceof BlockRotatedPillar) {
+									ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 4));
+									ItemDiggingShovel.breakableBlocks.addIfAbsent(new BlockEntry(sub, meta + 8));
+								}
 							}
 						}
 					}
+				} catch (Throwable e) {
 				}
 			}
-			catch (Throwable e) {}
 		}
-
 		CaverAPI.setMiningPointAmount("oreCoal", 1);
 		CaverAPI.setMiningPointAmount("oreIron", 1);
 		CaverAPI.setMiningPointAmount("oreGold", 1);

--- a/caveworld/core/Config.java
+++ b/caveworld/core/Config.java
@@ -108,6 +108,7 @@ public class Config
 	public static boolean showMinerRank;
 	public static String[] miningPoints;
 	public static String[] miningPointValidItems;
+	public static boolean disableMiningTools;
 	public static String[] randomiteDrops;
 	public static int[] randomitePotions;
 	public static boolean oreRenderOverlay;
@@ -352,6 +353,13 @@ public class Config
 		prop.comment = StatCollector.translateToLocal(prop.getLanguageKey() + ".tooltip");
 		propOrder.add(prop.getName());
 		miningPointValidItems = prop.getStringList();
+		prop = generalCfg.get(category, "disableMiningTools", false);
+		prop.setLanguageKey(Caveworld.CONFIG_LANG + category + '.' + prop.getName());
+		prop.comment = StatCollector.translateToLocal(prop.getLanguageKey() + ".tooltip");
+		prop.comment += " [default: " + prop.getDefault() + "]";
+		prop.comment += Configuration.NEW_LINE;
+		propOrder.add(prop.getName());
+		disableMiningTools = prop.getBoolean(disableMiningTools);
 		prop = generalCfg.get(category, "randomiteDrops", new String[0]);
 		prop.setMaxListLength(500).setLanguageKey(Caveworld.CONFIG_LANG + category + '.' + prop.getName()).setConfigEntryClass(selectItemsWithBlocks);
 		prop.comment = StatCollector.translateToLocal(prop.getLanguageKey() + ".tooltip");

--- a/caveworld/item/CaveItems.java
+++ b/caveworld/item/CaveItems.java
@@ -9,6 +9,7 @@
 
 package caveworld.item;
 
+import caveworld.core.Config;
 import com.google.common.base.Predicate;
 
 import caveworld.block.CaveBlocks;
@@ -120,14 +121,16 @@ public class CaveItems
 		OreDictionary.registerOre("gemCavenium", new ItemStack(cavenium, 1, 0));
 		OreDictionary.registerOre("refinedCavenium", new ItemStack(cavenium, 1, 1));
 		OreDictionary.registerOre("gemRefinedCavenium", new ItemStack(cavenium, 1, 1));
-		OreDictionary.registerOre("pickaxeMining", mining_pickaxe);
-		OreDictionary.registerOre("miningPickaxe", mining_pickaxe);
-		OreDictionary.registerOre("axeLumbering", lumbering_axe);
-		OreDictionary.registerOre("lumberingAxe", lumbering_axe);
-		OreDictionary.registerOre("shovelDigging", digging_shovel);
-		OreDictionary.registerOre("diggingShovel", digging_shovel);
-		OreDictionary.registerOre("hoeFarming", farming_hoe);
-		OreDictionary.registerOre("farmingHoe", farming_hoe);
+		if (!Config.disableMiningTools) {
+			OreDictionary.registerOre("pickaxeMining", mining_pickaxe);
+			OreDictionary.registerOre("miningPickaxe", mining_pickaxe);
+			OreDictionary.registerOre("axeLumbering", lumbering_axe);
+			OreDictionary.registerOre("lumberingAxe", lumbering_axe);
+			OreDictionary.registerOre("shovelDigging", digging_shovel);
+			OreDictionary.registerOre("diggingShovel", digging_shovel);
+			OreDictionary.registerOre("hoeFarming", farming_hoe);
+			OreDictionary.registerOre("farmingHoe", farming_hoe);
+		}
 		OreDictionary.registerOre("bowCavenic", cavenic_bow);
 		OreDictionary.registerOre("cavenicBow", cavenic_bow);
 		OreDictionary.registerOre("oreCompass", ore_compass);
@@ -184,38 +187,40 @@ public class CaveItems
 		GameRegistry.addShapelessRecipe(new ItemStack(cavenium, 9, 0), new ItemStack(CaveBlocks.cavenium_ore, 1, 2));
 		GameRegistry.addShapelessRecipe(new ItemStack(cavenium, 9, 1), new ItemStack(CaveBlocks.cavenium_ore, 1, 3));
 
-		GameRegistry.addRecipe(new RecipeCaveniumTool(new ItemStack(mining_pickaxe), new Predicate<ItemStack>()
-		{
-			@Override
-			public boolean apply(ItemStack itemstack)
+		if (!Config.disableMiningTools) {
+			GameRegistry.addRecipe(new RecipeCaveniumTool(new ItemStack(mining_pickaxe), new Predicate<ItemStack>()
 			{
-				return CaveUtils.isItemPickaxe(itemstack);
-			}
-		}));
-		GameRegistry.addRecipe(new RecipeCaveniumTool(new ItemStack(lumbering_axe), new Predicate<ItemStack>()
-		{
-			@Override
-			public boolean apply(ItemStack itemstack)
+				@Override
+				public boolean apply(ItemStack itemstack)
+				{
+					return CaveUtils.isItemPickaxe(itemstack);
+				}
+			}));
+			GameRegistry.addRecipe(new RecipeCaveniumTool(new ItemStack(lumbering_axe), new Predicate<ItemStack>()
 			{
-				return CaveUtils.isItemAxe(itemstack);
-			}
-		}));
-		GameRegistry.addRecipe(new RecipeCaveniumTool(new ItemStack(digging_shovel), new Predicate<ItemStack>()
-		{
-			@Override
-			public boolean apply(ItemStack itemstack)
+				@Override
+				public boolean apply(ItemStack itemstack)
+				{
+					return CaveUtils.isItemAxe(itemstack);
+				}
+			}));
+			GameRegistry.addRecipe(new RecipeCaveniumTool(new ItemStack(digging_shovel), new Predicate<ItemStack>()
 			{
-				return CaveUtils.isItemShovel(itemstack);
-			}
-		}));
-		GameRegistry.addRecipe(new RecipeFarmingHoe(new ItemStack(farming_hoe), new Predicate<ItemStack>()
-		{
-			@Override
-			public boolean apply(ItemStack itemstack)
+				@Override
+				public boolean apply(ItemStack itemstack)
+				{
+					return CaveUtils.isItemShovel(itemstack);
+				}
+			}));
+			GameRegistry.addRecipe(new RecipeFarmingHoe(new ItemStack(farming_hoe), new Predicate<ItemStack>()
 			{
-				return CaveUtils.isItemHoe(itemstack);
-			}
-		}));
+				@Override
+				public boolean apply(ItemStack itemstack)
+				{
+					return CaveUtils.isItemHoe(itemstack);
+				}
+			}));
+		}
 
 		GameRegistry.addRecipe(new RecipeCavenicBow(new ItemStack(cavenic_bow)));
 

--- a/caveworld/item/ItemDiggingShovel.java
+++ b/caveworld/item/ItemDiggingShovel.java
@@ -666,17 +666,19 @@ public class ItemDiggingShovel extends ItemCaveShovel implements ICaveniumTool
 	@Override
 	public void addInformation(ItemStack itemstack, EntityPlayer player, List list, boolean advanced)
 	{
-		list.add(getModeInfomation(itemstack));
+		if (Config.disableMiningTools) {
+			list.add(StatCollector.translateToLocal("caveworld.disabled"));
+		} else {
+			list.add(getModeInfomation(itemstack));
 
-		Item item = getBase(itemstack);
+			Item item = getBase(itemstack);
 
-		if (item != this)
-		{
-			list.add(I18n.format(getUnlocalizedName() + ".base") + ": " + item.getItemStackDisplayName(itemstack));
+			if (item != this) {
+				list.add(I18n.format(getUnlocalizedName() + ".base") + ": " + item.getItemStackDisplayName(itemstack));
 
-			item.addInformation(itemstack, player, list, advanced);
+				item.addInformation(itemstack, player, list, advanced);
+			}
 		}
-
 		super.addInformation(itemstack, player, list, advanced);
 	}
 

--- a/caveworld/item/ItemFarmingHoe.java
+++ b/caveworld/item/ItemFarmingHoe.java
@@ -542,17 +542,19 @@ public class ItemFarmingHoe extends ItemCaveHoe implements IModeItem
 	@Override
 	public void addInformation(ItemStack itemstack, EntityPlayer player, List list, boolean advanced)
 	{
-		list.add(getModeInfomation(itemstack));
+		if (Config.disableMiningTools) {
+			list.add(StatCollector.translateToLocal("caveworld.disabled"));
+		} else {
+			list.add(getModeInfomation(itemstack));
 
-		Item item = getBase(itemstack);
+			Item item = getBase(itemstack);
 
-		if (item != this)
-		{
-			list.add(I18n.format(getUnlocalizedName() + ".base") + ": " + item.getItemStackDisplayName(itemstack));
+			if (item != this) {
+				list.add(I18n.format(getUnlocalizedName() + ".base") + ": " + item.getItemStackDisplayName(itemstack));
 
-			item.addInformation(itemstack, player, list, advanced);
+				item.addInformation(itemstack, player, list, advanced);
+			}
 		}
-
 		super.addInformation(itemstack, player, list, advanced);
 	}
 

--- a/caveworld/item/ItemLumberingAxe.java
+++ b/caveworld/item/ItemLumberingAxe.java
@@ -714,17 +714,19 @@ public class ItemLumberingAxe extends ItemCaveAxe implements ICaveniumTool
 	@Override
 	public void addInformation(ItemStack itemstack, EntityPlayer player, List list, boolean advanced)
 	{
-		list.add(getModeInfomation(itemstack));
+		if (Config.disableMiningTools) {
+			list.add(StatCollector.translateToLocal("caveworld.disabled"));
+		} else {
+			list.add(getModeInfomation(itemstack));
 
-		Item item = getBase(itemstack);
+			Item item = getBase(itemstack);
 
-		if (item != this)
-		{
-			list.add(I18n.format(getUnlocalizedName() + ".base") + ": " + item.getItemStackDisplayName(itemstack));
+			if (item != this) {
+				list.add(I18n.format(getUnlocalizedName() + ".base") + ": " + item.getItemStackDisplayName(itemstack));
 
-			item.addInformation(itemstack, player, list, advanced);
+				item.addInformation(itemstack, player, list, advanced);
+			}
 		}
-
 		super.addInformation(itemstack, player, list, advanced);
 	}
 

--- a/caveworld/item/ItemMiningPickaxe.java
+++ b/caveworld/item/ItemMiningPickaxe.java
@@ -678,17 +678,19 @@ public class ItemMiningPickaxe extends ItemCavePickaxe implements ICaveniumTool
 	@Override
 	public void addInformation(ItemStack itemstack, EntityPlayer player, List list, boolean advanced)
 	{
-		list.add(getModeInfomation(itemstack));
+		if (Config.disableMiningTools) {
+			list.add(StatCollector.translateToLocal("caveworld.disabled"));
+		} else {
+			list.add(getModeInfomation(itemstack));
 
-		Item item = getBase(itemstack);
+			Item item = getBase(itemstack);
 
-		if (item != this)
-		{
-			list.add(I18n.format(getUnlocalizedName() + ".base") + ": " + item.getItemStackDisplayName(itemstack));
+			if (item != this) {
+				list.add(I18n.format(getUnlocalizedName() + ".base") + ": " + item.getItemStackDisplayName(itemstack));
 
-			item.addInformation(itemstack, player, list, advanced);
+				item.addInformation(itemstack, player, list, advanced);
+			}
 		}
-
 		super.addInformation(itemstack, player, list, advanced);
 	}
 

--- a/caveworld/plugin/craftguide/CraftGuidePlugin.java
+++ b/caveworld/plugin/craftguide/CraftGuidePlugin.java
@@ -9,6 +9,7 @@
 
 package caveworld.plugin.craftguide;
 
+import caveworld.core.Config;
 import caveworld.item.CaveItems;
 import caveworld.plugin.ICavePlugin;
 import cpw.mods.fml.common.Loader;
@@ -48,9 +49,11 @@ public class CraftGuidePlugin implements ICavePlugin
 	@Override
 	public void invoke()
 	{
-		new CaveniumToolRecipeProvider(new ItemStack(CaveItems.mining_pickaxe));
-		new CaveniumToolRecipeProvider(new ItemStack(CaveItems.lumbering_axe));
-		new CaveniumToolRecipeProvider(new ItemStack(CaveItems.digging_shovel));
-		new FarmingHoeRecipeProvider(new ItemStack(CaveItems.farming_hoe));
+		if (!Config.disableMiningTools) {
+			new CaveniumToolRecipeProvider(new ItemStack(CaveItems.mining_pickaxe));
+			new CaveniumToolRecipeProvider(new ItemStack(CaveItems.lumbering_axe));
+			new CaveniumToolRecipeProvider(new ItemStack(CaveItems.digging_shovel));
+			new FarmingHoeRecipeProvider(new ItemStack(CaveItems.farming_hoe));
+		}
 	}
 }

--- a/caveworld/plugin/mceconomy/MCEconomyPlugin.java
+++ b/caveworld/plugin/mceconomy/MCEconomyPlugin.java
@@ -133,10 +133,12 @@ public class MCEconomyPlugin implements ICavePlugin
 		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveBlocks.cavenia_portal), -1);
 		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.cavenium, 1, 0), 200);
 		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.cavenium, 1, 1), 500);
-		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.mining_pickaxe), -1);
-		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.lumbering_axe), -1);
-		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.digging_shovel), -1);
-		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.farming_hoe), -1);
+		if (!Config.disableMiningTools) {
+			MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.mining_pickaxe), -1);
+			MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.lumbering_axe), -1);
+			MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.digging_shovel), -1);
+			MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.farming_hoe), -1);
+		}
 		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.cavenic_bow), -1);
 		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.ore_compass), 2200);
 		MCEconomyAPI.addPurchaseItem(new ItemStack(CaveItems.gem, 1, 0), 35);


### PR DESCRIPTION
Adds an option to disable the cavenium based tools.
These tools store a lot of data in their NBT tags which can lead to server issues. In our case, people got dumped and were unable to reconnect because of too big data packets

```
io.netty.handler.codec.DecoderException: java.io.IOException: Packet was larger than I expected, found 51487 bytes extra whilst reading packet 53
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:263) ~[ByteToMessageDecoder.class:?]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:131) ~[ByteToMessageDecoder.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:173) [ByteToMessageDecoder.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) [MessageToMessageDecoder.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
	at io.netty.handler.timeout.ReadTimeoutHandler.channelRead(ReadTimeoutHandler.java:149) [ReadTimeoutHandler.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) [DefaultChannelPipeline.class:?]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:100) [AbstractNioByteChannel$NioByteUnsafe.class:?]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:480) [NioEventLoop.class:?]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:447) [NioEventLoop.class:?]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:341) [NioEventLoop.class:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101) [SingleThreadEventExecutor$2.class:?]
	at java.lang.Thread.run(Unknown Source) [?:1.8.0_92]
Caused by: java.io.IOException: Packet was larger than I expected, found 51487 bytes extra whilst reading packet 53
	at net.minecraft.util.MessageDeserializer.decode(SourceFile:42) ~[ez.class:?]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:232) ~[ByteToMessageDecoder.class:?]
	... 19 more
[16:28:14] [Netty Client IO #2/ERROR] [FML/]: NetworkDispatcher exception
io.netty.handler.codec.DecoderException: java.io.IOException: Packet was larger than I expected, found 51478 bytes extra whilst reading packet 31
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:263) ~[ByteToMessageDecoder.class:?]
	at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:196) ~[ByteToMessageDecoder.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:237) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:223) [DefaultChannelHandlerContext.class:?]
	at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:214) [ByteToMessageDecoder.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:237) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:223) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) [ChannelInboundHandlerAdapter.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:237) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:223) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) [ChannelInboundHandlerAdapter.class:?]
	at io.netty.handler.timeout.ReadTimeoutHandler.channelInactive(ReadTimeoutHandler.java:143) [ReadTimeoutHandler.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:237) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:223) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:767) [DefaultChannelPipeline.class:?]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$5.run(AbstractChannel.java:558) [AbstractChannel$AbstractUnsafe$5.class:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:354) [SingleThreadEventExecutor.class:?]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:348) [NioEventLoop.class:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101) [SingleThreadEventExecutor$2.class:?]
	at java.lang.Thread.run(Unknown Source) [?:1.8.0_92]
Caused by: java.io.IOException: Packet was larger than I expected, found 51478 bytes extra whilst reading packet 31
	at net.minecraft.util.MessageDeserializer.decode(SourceFile:42) ~[ez.class:?]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:232) ~[ByteToMessageDecoder.class:?]
	... 19 more
```

This is of course not a true fix, it would be much better if the tools didn't store this data at all, but this is something you can activate if your pack triggers this issue.

Note: To get rid of bugged tools you still need to start the server without caveworld once, I couldn't fully deactivate them because I wasn't sure if that would cause the mod to break somewhere else.